### PR TITLE
Update base image and specify versions

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,18 @@
+name: check
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .github/workflows/hadolint.yml
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: hadolint
+      uses: burdzwastaken/hadolint-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HADOLINT_ACTION_DOCKERFILE_FOLDER: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
-FROM bebit/python-mecab-builder:release-1.0 as builder
-
+FROM bebit/python-mecab-builder:release-1.1 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 
 FROM python:3.5-slim-stretch
-RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends default-libmysqlclient-dev mecab mecab-ipadic-utf8 libmecab-dev swig > /dev/null
+RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
+    default-libmysqlclient-dev=1.0.2 \
+    mecab=0.996-3.1 \
+    mecab-ipadic-utf8=2.7.0-20070801+main-1 \
+    libmecab-dev=0.996-3.1 \
+    swig=3.0.10-1.1 > /dev/null \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN sed -i -r 's/^dicdir = .*$$/dicdir = \/var\/lib\/mecab\/dic\/mecab-ipadic-neologd/' /etc/mecabrc
 COPY --from=builder /var/lib/mecab/dic/mecab-ipadic-neologd /var/lib/mecab/dic/mecab-ipadic-neologd


### PR DESCRIPTION
# why

- To use latest `python-mecab-builder:release-1.1`

# what

- Change base image
- Specify the versions
- Add `hadolint`
