### PR TITLE
Update from python 3.5-slim-stretch to python 3.7-slim-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM bebit/python-mecab-builder:release-1.1 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 
-FROM python:3.5-slim-stretch
+FROM python:3.7-slim-stretch
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     default-libmysqlclient-dev=1.0.2 \
     mecab=0.996-3.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bebit/python-mecab-builder:release-1.1 as builder
+FROM bebit/python-mecab-builder:dev as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 


### PR DESCRIPTION
## Why
Need to update python version to `3.7.9`.

## What
- Recently PR [#663](https://github.com/bebit/user-app-server-side/pull/663) was merged to the `master` branch.
But to merge the latest `master` into `django_dx_improvement` branch, we need to update the two base image from python `3.5.6` to ~`3.7.8`~ `3.7.9`.
- In order to use the `bebit/python-mecab-builder:dev` image we need to send this PR from `dev` (ref https://github.com/bebit/python-mecab-builder/pull/4#issuecomment-674728076). Although I'm not sure if this is the correct way of doing it because there doesn't seem to be any auto build being generated

## Jira
[UG-6043](https://bebit-sw.atlassian.net/browse/UG-6043)

## Additional notes

- Will need to create a new image tag `bebit/python-mecab-builder:dev` before merging this PR - https://github.com/bebit/python-mecab/pull/2
- Will update the README in a different PR.
