### PR TITLE
Merge 'dev' to 'master' for 'django_dx_improvement' release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bebit/python-mecab-builder:dev as builder
+FROM bebit/python-mecab-builder:release-1.2 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bebit/python-mecab-builder:release-1.2 as builder
+FROM bebit/python-mecab-builder:release-2.0 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM bebit/python-mecab-builder:release-1.1 as builder
+FROM bebit/python-mecab-builder:dev as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 
-FROM python:3.5-slim-stretch
+FROM python:3.7-slim-stretch
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     default-libmysqlclient-dev=1.0.2 \
     mecab=0.996-3.1 \


### PR DESCRIPTION
## What
Merge `dev` branch to `master`

## Why
- New changes in `django_dx_improvement` uses python `3.7`
- Updated `python-mecab-builder` image from `dev` to `release-1.2`
- Prepare for release as part of `django_dx_improvement`

## Ticket
[UG-6060](https://bebit-sw.atlassian.net/browse/UG-6060)

## References
https://bebit.slack.com/archives/CRZRZ67S9/p1599006497169000
https://github.com/bebit/python-mecab-builder/releases
