### PR TITLE
UG-6305: Added empty space to re-build image for slim-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 RUN sed -i -r 's/^dicdir = .*$$/dicdir = \/var\/lib\/mecab\/dic\/mecab-ipadic-neologd/' /etc/mecabrc
 COPY --from=builder /var/lib/mecab/dic/mecab-ipadic-neologd /var/lib/mecab/dic/mecab-ipadic-neologd
+


### PR DESCRIPTION
Fixes: https://github.com/bebit/user-app-server-side/issues/999

## Additional info:
- The last commit for `3.7-slim-stretch` was 16 days ago from today （2020/11/17）
- This image is managed externally so there's no need for us to do any major changes. Just re-building will solve the error logs marked critical on AWS is fine.

## References:
https://github.com/docker-library/python/commit/19f13795f4dc81038c93446879c11ea51ba3e260