### PR TITLE
UK-1107: Update Debian to version 10 and add CIs

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,48 @@
+name: Build and Push Docker Image
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+    types:
+      - opened # default
+      - synchronize # default
+      - reopened # default
+      - ready_for_review # draft -> ready
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io/bebit
+  IMAGE_NAME: "${{ github.event_name == 'release' && 'python-mecab' || 'python-mecab-dev' }}"
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder-dev:pr-13 as builder
+FROM ghcr.io/bebit/python-mecab-builder:3.0 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM bebit/python-mecab-builder:release-2.0 as builder
+FROM ghcr.io/bebit/python-mecab-builder-dev:pr-13 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-buster
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
-    default-libmysqlclient-dev=1.0.2 \
-    mecab=0.996-3.1 \
-    mecab-ipadic-utf8=2.7.0-20070801+main-1 \
-    libmecab-dev=0.996-3.1 \
-    swig=3.0.10-1.1 > /dev/null \
+    default-libmysqlclient-dev=1.0.5 \
+    mecab=0.996-6 \
+    mecab-ipadic-utf8=2.7.0-20070801+main-2.1 \
+    libmecab-dev=0.996-6 \
+    swig=3.0.12-2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN sed -i -r 's/^dicdir = .*$$/dicdir = \/var\/lib\/mecab\/dic\/mecab-ipadic-neologd/' /etc/mecabrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     mecab=0.996-6 \
     mecab-ipadic-utf8=2.7.0-20070801+main-2.1 \
     libmecab-dev=0.996-6 \
-    swig=3.0.12-2 \
+    swig=3.0.12-2 > /dev/null \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN sed -i -r 's/^dicdir = .*$$/dicdir = \/var\/lib\/mecab\/dic\/mecab-ipadic-neologd/' /etc/mecabrc

--- a/README.md
+++ b/README.md
@@ -3,21 +3,8 @@
 `Python 3.7` with `mecab` dependencies.
 
 ## How to use
-In your `DOCKERFILE` specify your image with a release build as its tag.
-
-e.g. To use this image with the `release-1.1` build you would include something like below:
-```yml
-    docker:
-      - image: bebit/python-mecab:release-1.1
-```
-
-## Updating image dependencies
-
-E.g. If you wanted to change from `python 3.7.9` to `python 3.5.6` you would just update the image tag like below:
-
-```diff
-- FROM python:3.7-slim-stretch
-+ FROM python:3.5-slim-stretch
-```
-
-Then push your changes to a branch on the `beBit` repo and then your branch name is served as an image tag. e.g. Your branch name `python_mecab_python-3.5.6` will be written as `bebit/python-mecab:python_mecab_python-3.5.6` in your `DOCKERFILE`
+- Until 2.0 release, docker images are stored in https://hub.docker.com/r/bebit/python-mecab
+- Later releases are stored in Github Container Registry
+  - Dev: https://github.com/orgs/bebit/packages/container/package/python-mecab-dev
+  - Prod: https://github.com/orgs/bebit/packages/container/package/python-mecab
+- For the build and push workflow, refer to [build-and-push.yml](.github/workflows/build-and-push.yml)


### PR DESCRIPTION
# Related PR
- https://github.com/bebit/python-mecab-builder/pull/13

# Why
- Debian 9 (stretch) python image is no longer supported and contains a lot of Vulnerability Issues

# What
- Upgrade python 3.7 image to Debian 10 - Bluster. https://github.com/docker-library/python/tree/master/3.7
- Upgrade apt-packages versions to the one supported in Debian 10.
- Add CI to build and push docker image to Github container registry
  -  Auto build of docker hub is no longer available for Docker Hub
  - Using Github Container Registry is simpler and doesn't require any extra effort for configuring token. (Docker hub requires Personal access token which is hard to maintain)
  - GCR is free for public repos

# Reference
https://packages.debian.org/buster/default-libmysqlclient-dev
https://packages.debian.org/buster/mecab
https://packages.debian.org/buster/mecab-ipadic-utf8
https://packages.debian.org/buster/libmecab-dev
https://packages.debian.org/buster/swig

# Tested with e2e and manually
- e2e: https://github.com/bebit/eks-prod/pull/10542
- https://infra-check.bebit-dev.com/