### PR TITLE
UK-12846: upgrade to python 3.10

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.10.2
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - .github/workflows/build-and-push.yml
     types:
       - opened # default
       - synchronize # default
@@ -26,8 +27,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,14 +39,15 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder-dev:pr-14 as builder
+FROM ghcr.io/bebit/python-mecab-builder-dev:pr-15 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ghcr.io/bebit/python-mecab-builder:3.0 as builder
+FROM ghcr.io/bebit/python-mecab-builder-dev:pr-14 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 
-FROM python:3.7-slim-buster
+FROM python:3.10-slim-buster
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
     default-libmysqlclient-dev=1.0.5 \
     mecab=0.996-6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder-dev:pr-15 as builder
+FROM ghcr.io/bebit/python-mecab-builder:4.0 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder:4.0 as builder
+FROM ghcr.io/bebit/python-mecab-builder:4.1 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-mecab
 
-`Python 3.7` with `mecab` dependencies.
+`Python 3.10` with `mecab` dependencies.
 
 ## How to use
 - Until 2.0 release, docker images are stored in https://hub.docker.com/r/bebit/python-mecab


### PR DESCRIPTION
# Why
upgrade to python 3.10 
# What 
change base image to use python 3.10
# When
Need to wait for https://github.com/bebit/python-mecab-builder/pull/14 is merged and use the latest image.