### PR TITLE
Support multi-platform build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,12 +39,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - .github/workflows/build-and-push.yml
     types:
       - opened # default
       - synchronize # default
@@ -26,6 +27,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -46,3 +50,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder-dev:pr-14 as builder
+FROM ghcr.io/bebit/python-mecab-builder-dev:pr-15 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 


### PR DESCRIPTION
# Why

To support `linux/arm64` arch for M1 mac
https://bebit.slack.com/archives/C047RE2K4H1/p1675847580482259

# What

update workflow to support `linux/arm64`

- prev build doesn't have `OS / Arch` tab
  - https://github.com/bebit/python-mecab/pkgs/container/python-mecab-dev/67880849?tag=pr-9
- this PR has
   -  https://github.com/bebit/python-mecab/pkgs/container/python-mecab-dev/69023031?tag=pr-10

# How to check in local

```
docker pull ghcr.io/bebit/python-mecab-dev:pr-10
docker image inspect ghcr.io/bebit/python-mecab-dev:pr-10 | grep Architecture
```