### PR TITLE
UK-18616: Update security patches for libexpat1 and ncurses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
 
 FROM python:3.10-slim-buster
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
+    libexpat1=2.2.6-2+deb10u7 \
+    libncursesw6=6.1+20181013-2+deb10u5 \
+    ncurses-base=6.1+20181013-2+deb10u5 \
+    ncurses-bin=6.1+20181013-2+deb10u5 \
     default-libmysqlclient-dev=1.0.5 \
     mecab=0.996-6 \
     mecab-ipadic-utf8=2.7.0-20070801+main-2.1 \


### PR DESCRIPTION
# WHY
As investigated in https://bebit-sw.atlassian.net/wiki/spaces/UG/pages/3113222147/UGA+Investigation+-+user-app-server-side+vulnerability#Todo we should upgrade `libexpat1` an `ncurses` related to the latest version provided for debian bluster to fix the remaining CVE

# WHAT
- Update `libexpat1` to `2.2.6-2+deb10u7` https://packages.debian.org/buster/libexpat1
- Update `ncurses` related packages to `6.1+20181013-2+deb10u5 `
  - https://packages.debian.org/buster/libncursesw6
  - https://packages.debian.org/buster/ncurses-base
  - https://packages.debian.org/buster/ncurses-bin
- Old version
```
docker run -it ghcr.io/bebit/python-mecab:4.0 bash
root@a1aed9e0cfdc:/# apt list --installed | grep xpat

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

libexpat1/now 2.2.6-2+deb10u6 amd64 [installed,local]
apt list --installed | grep ncurse

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

libncursesw6/now 6.1+20181013-2+deb10u3 amd64 [installed,local]
ncurses-base/now 6.1+20181013-2+deb10u3 all [installed,local]
ncurses-bin/now 6.1+20181013-2+deb10u3 amd64 [installed,local]
```
# TEST
https://bebit-sw.atlassian.net/wiki/spaces/UG/pages/3136684033/2024-07-25+user-app-server-side+Test+vulnerability+fixes+for+python-mecab+base+image