### PR TITLE
UK-20532: Upgrade to python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder-dev:pr-21 as builder
+FROM ghcr.io/bebit/python-mecab-builder-dev:5.0 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder-dev:5.1 as builder
+FROM ghcr.io/bebit/python-mecab-builder:5.1 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bebit/python-mecab-builder-dev:5.0 as builder
+FROM ghcr.io/bebit/python-mecab-builder-dev:5.1 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM ghcr.io/bebit/python-mecab-builder:4.1 as builder
+FROM ghcr.io/bebit/python-mecab-builder-dev:pr-21 as builder
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git && \
     mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -y -n -p /var/lib/mecab/dic/mecab-ipadic-neologd
 
-FROM python:3.10-slim-buster
+FROM python:3.12-slim-bookworm
 RUN apt-get update > /dev/null && apt-get install -y --no-install-recommends \
-    libexpat1=2.2.6-2+deb10u7 \
-    libncursesw6=6.1+20181013-2+deb10u5 \
-    ncurses-base=6.1+20181013-2+deb10u5 \
-    ncurses-bin=6.1+20181013-2+deb10u5 \
-    default-libmysqlclient-dev=1.0.5 \
-    mecab=0.996-6 \
-    mecab-ipadic-utf8=2.7.0-20070801+main-2.1 \
-    libmecab-dev=0.996-6 \
-    swig=3.0.12-2 > /dev/null \
+    libexpat1=2.5.0-1+deb12u1 \
+    libncursesw6=6.4-4 \
+    ncurses-base=6.4-4 \
+    ncurses-bin=6.4-4 \
+    default-libmysqlclient-dev=1.1.0 \
+    mecab=0.996-14+b14 \
+    mecab-ipadic-utf8=2.7.0-20070801+main-3 \
+    libmecab-dev=0.996-14+b14 \
+    swig=4.1.0-0.2 > /dev/null \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN sed -i -r 's/^dicdir = .*$$/dicdir = \/var\/lib\/mecab\/dic\/mecab-ipadic-neologd/' /etc/mecabrc


### PR DESCRIPTION
# Why
Upgrade python to 3.12 (We would like to upgrade django to 5.2 together with python upgrade)
# What
- Update base image to python 3.12
- Update related dependencies
# When
When releasing python upgrade